### PR TITLE
Add Jest tests for InterviewCard icons

### DIFF
--- a/__tests__/InterviewCard.test.tsx
+++ b/__tests__/InterviewCard.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import InterviewCard from '@/app/components/InterviewCard';
+
+describe('getFeedbackIcon', () => {
+  it('returns correct icons for success, warning and info types', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<InterviewCard />);
+
+    // Start interview
+    await user.click(screen.getByRole('button', { name: /start your interview/i }));
+
+    // Provide answer
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'My answer');
+
+    // Submit answer to reveal feedback section
+    await user.click(screen.getByRole('button', { name: /submit answer/i }));
+
+    expect(container.querySelector('svg.text-green-500')).toBeInTheDocument();
+    expect(container.querySelector('svg.text-yellow-500')).toBeInTheDocument();
+    expect(container.querySelector('svg.text-blue-500')).toBeInTheDocument();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="jest" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "format": "prettier --write .",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "jest"
   },
   "dependencies": {
     "lucide-react": "^0.515.0",
@@ -32,6 +33,13 @@
     "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.5.11",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5.4.2"
+    "typescript": "^5.4.2",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.1.4",
+    "@testing-library/user-event": "^14.4.3",
+    "@types/jest": "^29.5.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.0",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest & React Testing Library configuration
- write a test verifying the feedback icons
- install test dependencies in package.json

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d89e129708322aa9e4687dc78233b