### PR TITLE
Enable interview completion view

### DIFF
--- a/app/components/GhostInterviewer.tsx
+++ b/app/components/GhostInterviewer.tsx
@@ -160,8 +160,14 @@ export default function GhostInterviewer() {
           >
             <Send className="w-6 h-6" />
           </button>
+          <button
+            onClick={() => setIsInterviewComplete(true)}
+            className="ml-auto px-4 py-2 bg-gray-200 rounded-2xl text-gray-700 hover:bg-gray-300"
+          >
+            Finish Interview
+          </button>
         </div>
       </div>
     </div>
   );
-} 
+}


### PR DESCRIPTION
## Summary
- add a button in `GhostInterviewer` to set `isInterviewComplete`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_684d89d9d67083228456eb9ba31dbc40