### PR TITLE
Fix repo name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ An AI-powered interview practice application that helps users improve their inte
 1. Clone the repository:
 ```bash
 git clone [repository-url]
-cd ghost-interviewer
+cd project-salamin
 ```
 
 2. Install dependencies:


### PR DESCRIPTION
## Summary
- correct directory name in Getting Started guide

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d89d579ac8322b2092636e9405233