### PR TITLE
Fix: Allow empty arrays in InterviewAnalyzer validation

### DIFF
--- a/app/utils/InterviewAnalyzer.ts
+++ b/app/utils/InterviewAnalyzer.ts
@@ -78,14 +78,14 @@ export class InterviewAnalyzer extends BaseAIService {
     this.validateResponseStructure(analysis, requiredFields);
     
     // Additional specific validations
-    if (!Array.isArray(analysis.strengths) || analysis.strengths.length === 0) {
-      throw new Error('Strengths must be a non-empty array');
+    if (!Array.isArray(analysis.strengths)) {
+      throw new Error('Strengths must be an array');
     }
-    if (!Array.isArray(analysis.weaknesses) || analysis.weaknesses.length === 0) {
-      throw new Error('Weaknesses must be a non-empty array');
+    if (!Array.isArray(analysis.weaknesses)) {
+      throw new Error('Weaknesses must be an array');
     }
-    if (!Array.isArray(analysis.suggestions) || analysis.suggestions.length === 0) {
-      throw new Error('Suggestions must be a non-empty array');
+    if (!Array.isArray(analysis.suggestions)) {
+      throw new Error('Suggestions must be an array');
     }
     if (typeof analysis.score !== 'number' || analysis.score < 0 || analysis.score > 100) {
       throw new Error('Score must be a number between 0 and 100');


### PR DESCRIPTION
## Summary
- Update InterviewAnalyzer validation to accept empty arrays for strengths, weaknesses, and suggestions
- Remove strict non-empty array requirements that could cause validation failures
- UI already handles empty states with appropriate placeholder messages

## Test plan
- [ ] Verify InterviewAnalyzer no longer throws errors for empty arrays
- [ ] Confirm UI displays placeholder messages when arrays are empty
- [ ] Run existing tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)