### PR TITLE
Add post-interview survey feedback button

### DIFF
--- a/app/components/InterviewOrchestrator.tsx
+++ b/app/components/InterviewOrchestrator.tsx
@@ -849,12 +849,6 @@ export default function InterviewOrchestrator() {
                     Next Question
                   </button>
                 )}
-                <button
-                  onClick={handleSaveFeedback}
-                  className="inline-flex items-center justify-center px-6 py-3 border border-gray-300 text-gray-800 rounded-lg hover:bg-gray-50 focus:ring-2 focus:ring-gray-400 focus:outline-none transition-colors"
-                >
-                  Save Feedback
-                </button>
               </>
             )}
           </div>

--- a/app/components/InterviewSummary.tsx
+++ b/app/components/InterviewSummary.tsx
@@ -8,7 +8,8 @@ import {
   Target,
   ArrowRight,
   FileText,
-  BookOpen
+  BookOpen,
+  MessageSquare
 } from 'lucide-react';
 import type { InterviewAnalysis } from '../utils/InterviewAnalysisService';
 import type { InterviewConfiguration } from '../types/interview';
@@ -169,13 +170,18 @@ export function InterviewSummary({
             Start New Interview
             <ArrowRight className="w-4 h-4" />
           </button>
-          <button
-            onClick={onReviewFeedback}
-            className="w-full inline-flex items-center justify-center gap-2 px-6 py-3 border border-gray-300 text-gray-800 rounded-lg hover:bg-gray-50 focus:ring-2 focus:ring-gray-400 focus:outline-none transition-colors"
+          
+          {/* Survey Feedback Button */}
+          <a
+            href="https://docs.google.com/forms/d/e/1FAIpQLSdVk0uOAyB05OmLt4DZR4Hq0Ztfv1kktm0jq6dLB9qu1jpLAA/viewform?usp=header"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="w-full inline-flex items-center justify-center gap-2 px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:outline-none transition-colors font-medium shadow-lg"
+            style={{ minHeight: '48px' }}
           >
-            Review All Feedback
-            <FileText className="w-4 h-4" />
-          </button>
+            Share Your Feedback
+            <MessageSquare className="w-4 h-4" />
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add "Share Your Feedback" button to the interview summary screen that opens a Google Form for collecting user feedback
- Remove unused "Save Feedback" and "Review All Feedback" buttons to streamline the UI
- Style the survey button with distinctive blue color and proper external link handling

## Changes Made
- **InterviewSummary.tsx**: Added survey feedback button with Google Form link, removed "Review All Feedback" button
- **InterviewOrchestrator.tsx**: Removed "Save Feedback" button from interview question flow

## Test Plan
- [ ] Complete a full interview session
- [ ] Verify the "Share Your Feedback" button appears on the summary screen
- [ ] Click the button to confirm it opens the Google Form in a new tab
- [ ] Verify the removed buttons no longer appear
- [ ] Test button styling and hover states

🤖 Generated with [Claude Code](https://claude.ai/code)