### PR TITLE
Improve feedback button clarity to prevent user confusion

### DIFF
--- a/app/components/InterviewSummary.tsx
+++ b/app/components/InterviewSummary.tsx
@@ -190,7 +190,7 @@ export function InterviewSummary({
             className="w-full inline-flex items-center justify-center gap-2 px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:outline-none transition-colors font-medium shadow-lg"
             style={{ minHeight: '48px' }}
           >
-            Share Your Feedback
+Help Us Improve
             <MessageSquare className="w-4 h-4" />
           </a>
         </div>


### PR DESCRIPTION
## Summary
• Changed "Share Your Feedback" button text to "Help Us Improve" 
• Prevents user confusion between sharing interview results vs providing platform feedback
• Makes the post-interview survey purpose clearer

## Test plan
- [ ] Verify button text displays as "Help Us Improve"
- [ ] Confirm button still links to the correct Google Forms survey
- [ ] Test button functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)